### PR TITLE
Fix database connection closed prematurely after reading metadata

### DIFF
--- a/src/org/openstreetmap/josm/plugins/mbtiles/mbtiles/MbtilesLayer.java
+++ b/src/org/openstreetmap/josm/plugins/mbtiles/mbtiles/MbtilesLayer.java
@@ -76,13 +76,6 @@ public class MbtilesLayer extends AbstractTileSourceLayer {
             }
         } catch (SQLException e) {
             throw new SqliteException(tr("This doesn't appear to be a valid mbtiles database."), e);
-        } finally {
-            try {
-                mbtilesConnection.close();
-            } catch (SQLException e) {
-                // connection close failed.
-                Logging.logWithStackTrace(Logging.LEVEL_WARN, "Error closing sqlite database", e);
-            }
         }
 
         ImageryInfo info = new ImageryInfo(tr("MBTiles: {0}", name));

--- a/src/test/java/org/openstreetmap/josm/plugins/mbtiles/MbtilesLayerTest.java
+++ b/src/test/java/org/openstreetmap/josm/plugins/mbtiles/MbtilesLayerTest.java
@@ -148,6 +148,45 @@ class MbtilesLayerTest {
         });
     }
 
+    /**
+     * Verifies that after reading metadata (as buildImageryInfo does),
+     * the connection is still open and usable for tile queries.
+     * This is a regression test for a bug where buildImageryInfo closed
+     * the connection in a finally block, causing all subsequent tile
+     * loads to fail with "database connection closed".
+     */
+    @Test
+    void connectionRemainsOpenAfterMetadataRead() throws Exception {
+        File dbFile = MbtilesTestUtils.createTestMbtilesDb(
+                "Connection Test", "-74.0,40.0,-73.0,41.0", 2, 14);
+        MbtilesTestUtils.insertTile(dbFile, 5, 10, 20, MbtilesTestUtils.createMinimalPng());
+
+        Connection conn = openReadOnly(dbFile);
+
+        // Phase 1: Read metadata (same queries as buildImageryInfo)
+        PreparedStatement metaStmt = conn.prepareStatement("SELECT name,value FROM metadata");
+        ResultSet metaRs = metaStmt.executeQuery();
+        while (metaRs.next()) {
+            metaRs.getString("name");
+            metaRs.getString("value");
+        }
+        metaRs.close();
+        metaStmt.close();
+
+        // Phase 2: Connection must still be usable for tile queries
+        assertFalse(conn.isClosed(), "Connection should remain open after reading metadata");
+
+        Statement tileStmt = conn.createStatement();
+        ResultSet tileRs = tileStmt.executeQuery(
+                "SELECT tile_data FROM tiles WHERE zoom_level=5 AND tile_column=10 AND tile_row=20 LIMIT 1");
+        assertTrue(tileRs.next(), "Tile query should succeed on the still-open connection");
+        assertNotNull(tileRs.getBytes(1), "Tile data should be readable");
+
+        tileRs.close();
+        tileStmt.close();
+        conn.close();
+    }
+
     private Connection openReadOnly(File dbFile) throws Exception {
         Class.forName("org.sqlite.JDBC");
         SQLiteConfig config = new SQLiteConfig();


### PR DESCRIPTION
## Summary

- `MbtilesLayer.buildImageryInfo()` was closing the database connection in a `finally` block immediately after reading metadata, but the same connection is reused by `MbtilesTileLoader` for all subsequent tile queries — causing every tile load to fail with "database connection closed"
- Removed the premature `connection.close()` from `buildImageryInfo()`. The connection is already properly closed in `MbtilesLayer.destroy()` when the layer is removed
- Added a regression test that verifies the connection remains open and usable for tile queries after metadata has been read

This is the actual fix for #28. PR #29 fixed the classloader issue that was preventing the SQLite driver from loading, but this pre-existing bug was masked by that error and only became visible once the driver loaded successfully.

Closes #28